### PR TITLE
Review addressed.

### DIFF
--- a/.changeset/smooth-olives-draw.md
+++ b/.changeset/smooth-olives-draw.md
@@ -1,0 +1,6 @@
+---
+"@kunai-consulting/qwik": patch
+"qwik-design-system-docs": patch
+---
+
+Clear headless scroll-area component.

--- a/apps/docs/public/pagefind/pagefind-entry.json
+++ b/apps/docs/public/pagefind/pagefind-entry.json
@@ -1,1 +1,1 @@
-{"version":"1.2.0","languages":{"en-us":{"hash":"en-us_816f13fae2e64","wasm":"en-us","page_count":9}}}
+{"version":"1.2.0","languages":{"en-us":{"hash":"en-us_31d920e3c96e6","wasm":"en-us","page_count":10}}}

--- a/apps/docs/src/routes/scroll-area/examples/scroll-area.css
+++ b/apps/docs/src/routes/scroll-area/examples/scroll-area.css
@@ -1,9 +1,5 @@
 .scroll-area-root {
     background: #0a4d70;
-    position: relative;
-    overflow: hidden;
-    width: 100%;
-    height: 100%;
     --thumb-size: 12px;
     --scroll-bar-size: 16px;
 }
@@ -12,39 +8,21 @@
     width: 100%;
     height: 100%;
     border-radius: inherit;
-    overflow: scroll;
-    position: relative;
-    scrollbar-width: none; /* Firefox */
-    -ms-overflow-style: none; /* IE and Edge */
-}
-
-/* Hide default scrollbars */
-.scroll-area-viewport::-webkit-scrollbar {
-    display: none;
 }
 
 .scroll-area-scrollbar {
-    display: flex;
-    touch-action: none;
-    user-select: none;
     padding: 2px;
     background: rgba(255, 255, 255, 0.12);
     transition: background 160ms ease-out;
-    position: absolute;
 }
 
 .scroll-area-scrollbar[data-orientation='vertical'] {
     width: 16px;
-    height: 100%;
-    right: 0;
-    top: 0;
 }
 
 .scroll-area-scrollbar[data-orientation='horizontal'] {
     height: 16px;
     width: calc(100% - var(--thumb-size));
-    bottom: 0;
-    left: 0;
 }
 
 .scroll-area-scrollbar[data-orientation='vertical'] .scroll-area-thumb {
@@ -58,7 +36,6 @@
 }
 
 .scroll-area-thumb {
-    position: relative;
     background: rgba(255, 255, 255, 0.4);
     border-radius: 9999px;
     transition: background 160ms ease-out;

--- a/libs/components/src/scroll-area/scroll-area-root.tsx
+++ b/libs/components/src/scroll-area/scroll-area-root.tsx
@@ -3,13 +3,16 @@ import {
   Slot,
   component$,
   useContextProvider,
-  useSignal
+  useSignal,
+  useStyles$
 } from "@builder.io/qwik";
 import { scrollAreaContextId } from "./scroll-area-context";
+import styles from "./scroll-area.css?inline";
 
 type RootProps = PropsOf<"div">;
 
 export const ScrollAreaRoot = component$<RootProps>((props) => {
+  useStyles$(styles);
   const viewportRef = useSignal<HTMLDivElement>();
   const scrollbarRef = useSignal<HTMLDivElement>();
   const thumbRef = useSignal<HTMLDivElement>();
@@ -23,7 +26,7 @@ export const ScrollAreaRoot = component$<RootProps>((props) => {
   useContextProvider(scrollAreaContextId, context);
 
   return (
-    <div {...props} data-scroll-area-root>
+    <div {...props} data-qds-scroll-area-root>
       <Slot />
     </div>
   );

--- a/libs/components/src/scroll-area/scroll-area-scrollbar.tsx
+++ b/libs/components/src/scroll-area/scroll-area-scrollbar.tsx
@@ -54,7 +54,7 @@ export const ScrollAreaScrollbar = component$<ScrollBarType>((props) => {
     <div
       {...props}
       ref={context.scrollbarRef}
-      data-scroll-area-scrollbar
+      data-qds-scroll-area-scrollbar
       data-orientation={orientation}
       onClick$={onTrackClick$}
     >

--- a/libs/components/src/scroll-area/scroll-area-thumb.tsx
+++ b/libs/components/src/scroll-area/scroll-area-thumb.tsx
@@ -94,7 +94,7 @@ export const ScrollAreaThumb = component$<ScrollAreaThumb>((props) => {
     <div
       {...props}
       ref={context.thumbRef}
-      data-scroll-area-thumb
+      data-qds-scroll-area-thumb
       data-dragging={isDragging.value ? "" : undefined}
       onMouseDown$={onDragStart$}
     />

--- a/libs/components/src/scroll-area/scroll-area-view-port.tsx
+++ b/libs/components/src/scroll-area/scroll-area-view-port.tsx
@@ -16,26 +16,33 @@ export const ScrollAreaViewport = component$<ViewPortProps>((props) => {
   const context = useContext(scrollAreaContextId);
   const onScroll$ = $((e: Event) => {
     const viewport = e.target as HTMLElement;
-    const scrollbars = Array.from(
-      viewport.parentElement?.querySelectorAll("[data-scroll-area-scrollbar]") || []
-    );
+    const root = viewport.parentElement;
+    if (!root) return;
 
-    for (const scrollbar of scrollbars) {
-      const thumb = scrollbar.querySelector("[data-scroll-area-thumb]") as HTMLElement;
-      if (!thumb) return;
+    const verticalScrollbar = root.querySelector(
+      '[data-qds-scroll-area-scrollbar][data-orientation="vertical"]'
+    ) as HTMLElement;
+    const horizontalScrollbar = root.querySelector(
+      '[data-qds-scroll-area-scrollbar][data-orientation="horizontal"]'
+    ) as HTMLElement;
 
-      const isVertical = scrollbar.getAttribute("data-orientation") === "vertical";
-
-      if (isVertical) {
+    if (verticalScrollbar) {
+      const verticalThumb = verticalScrollbar.querySelector("[data-qds-scroll-area-thumb]") as HTMLElement;
+      if (verticalThumb) {
         const scrollRatio =
           viewport.scrollTop / (viewport.scrollHeight - viewport.clientHeight);
-        const maxTop = scrollbar.clientHeight - thumb.clientHeight;
-        thumb.style.transform = `translateY(${scrollRatio * maxTop}px)`;
-      } else {
+        const maxTop = verticalScrollbar.clientHeight - verticalThumb.clientHeight;
+        verticalThumb.style.transform = `translateY(${scrollRatio * maxTop}px)`;
+      }
+    }
+
+    if (horizontalScrollbar) {
+      const horizontalThumb = horizontalScrollbar.querySelector("[data-qds-scroll-area-thumb]") as HTMLElement;
+      if (horizontalThumb) {
         const scrollRatio =
           viewport.scrollLeft / (viewport.scrollWidth - viewport.clientWidth);
-        const maxLeft = scrollbar.clientWidth - thumb.clientWidth;
-        thumb.style.transform = `translateX(${scrollRatio * maxLeft}px)`;
+        const maxLeft = horizontalScrollbar.clientWidth - horizontalThumb.clientWidth;
+        horizontalThumb.style.transform = `translateX(${scrollRatio * maxLeft}px)`;
       }
     }
 
@@ -46,9 +53,10 @@ export const ScrollAreaViewport = component$<ViewPortProps>((props) => {
   return (
     <div
       {...props}
-      data-scroll-area-viewport
-      onScroll$={onScroll$}
+      data-qds-scroll-area-viewport
+      onScroll$={[onScroll$, props.onScroll$]}
       ref={context.viewportRef}
+      tabIndex={0} //don't remove this line; it's needed to avoid a11y issues
       role="region"
       aria-label="Scrollable content"
     >

--- a/libs/components/src/scroll-area/scroll-area.css
+++ b/libs/components/src/scroll-area/scroll-area.css
@@ -1,0 +1,39 @@
+@layer qds {
+    [data-qds-scroll-area-root] {
+        position: relative;
+        overflow: hidden;
+    }
+
+    [data-qds-scroll-area-viewport] {
+        overflow: scroll;
+        position: relative;
+        scrollbar-width: none; /* Firefox */
+        -ms-overflow-style: none; /* IE and Edge */
+    }
+
+    /* Hide default scrollbars */
+    [data-qds-scroll-area-viewport]::-webkit-scrollbar {
+        display: none;
+    }
+
+    [data-qds-scroll-area-scrollbar] {
+        touch-action: none;
+        user-select: none;
+        position: absolute;
+    }
+
+    [data-qds-scroll-area-scrollbar][data-orientation='vertical'] {
+        height: 100%;
+        right: 0;
+        top: 0;
+    }
+
+    [data-qds-scroll-area-scrollbar][data-orientation='horizontal'] {
+        bottom: 0;
+        left: 0;
+    }
+
+    [data-qds-scroll-area-thumb] {
+        position: relative;
+    }
+}

--- a/libs/components/src/scroll-area/scroll-area.driver.ts
+++ b/libs/components/src/scroll-area/scroll-area.driver.ts
@@ -3,31 +3,31 @@ export type DriverLocator = Locator | Page;
 
 export function createTestDriver<T extends DriverLocator>(rootLocator: T) {
   const getRoot = () => {
-    return rootLocator.locator("[data-scroll-area-root]");
+    return rootLocator.locator("[data-qds-scroll-area-root]");
   };
 
   const getViewport = () => {
-    return rootLocator.locator("[data-scroll-area-viewport]");
+    return rootLocator.locator("[data-qds-scroll-area-viewport]");
   };
 
   const getVerticalScrollbar = () => {
     return rootLocator.locator(
-      '[data-scroll-area-scrollbar][data-orientation="vertical"]'
+      '[data-qds-scroll-area-scrollbar][data-orientation="vertical"]'
     );
   };
 
   const getHorizontalScrollbar = () => {
     return rootLocator.locator(
-      '[data-scroll-area-scrollbar][data-orientation="horizontal"]'
+      '[data-qds-scroll-area-scrollbar][data-orientation="horizontal"]'
     );
   };
 
   const getVerticalThumb = () => {
-    return getVerticalScrollbar().locator("[data-scroll-area-thumb]");
+    return getVerticalScrollbar().locator("[data-qds-scroll-area-thumb]");
   };
 
   const getHorizontalThumb = () => {
-    return getHorizontalScrollbar().locator("[data-scroll-area-thumb]");
+    return getHorizontalScrollbar().locator("[data-qds-scroll-area-thumb]");
   };
 
   const getViewportAttributes = async () => {

--- a/libs/components/src/scroll-area/scroll-area.test.ts
+++ b/libs/components/src/scroll-area/scroll-area.test.ts
@@ -350,7 +350,7 @@ test.describe("a11y", () => {
       await Promise.all([
         viewport.evaluate(() => {
           return new Promise((resolve) => {
-            const el = document.querySelector("[data-scroll-area-viewport]");
+            const el = document.querySelector("[data-qds-scroll-area-viewport]");
             if (!el) {
               resolve(null);
               return;


### PR DESCRIPTION
* The headless component should have a new @layer css file.
* Prefix every component data attribute with qds.
* Events need to be using an array so that consumers can pass their own props.
* Using refs, not querySelector.

Regarding using ref instead of querySelector, this solution was chosen for cases where we have two scrollbars on the page. I’ve updated the current implementation, but it won’t be possible to eliminate querySelector completely. We still need it to determine the scrollbar orientation.

Please see [here](https://github.com/kunai-consulting/qwik-design-system/compare/scroll-area-feedback?expand=1#diff-afdddcb0c90a68561090c60d8f7345002383e827d2d4aeee7ed713ce1adc2d7aR22) and [here](https://github.com/kunai-consulting/qwik-design-system/compare/scroll-area-feedback?expand=1#diff-afdddcb0c90a68561090c60d8f7345002383e827d2d4aeee7ed713ce1adc2d7aR26)