### PR TITLE
Avoid querySelector and parentElement.

### DIFF
--- a/.changeset/curvy-penguins-shave.md
+++ b/.changeset/curvy-penguins-shave.md
@@ -1,0 +1,6 @@
+---
+"@kunai-consulting/qwik": patch
+"qwik-design-system-docs": patch
+---
+
+Avoid querySelector and parentElement.

--- a/.changeset/curvy-penguins-shave.md
+++ b/.changeset/curvy-penguins-shave.md
@@ -1,6 +1,5 @@
 ---
 "@kunai-consulting/qwik": patch
-"qwik-design-system-docs": patch
 ---
 
 Avoid querySelector and parentElement.

--- a/apps/docs/public/pagefind/pagefind-entry.json
+++ b/apps/docs/public/pagefind/pagefind-entry.json
@@ -1,1 +1,1 @@
-{"version":"1.2.0","languages":{"en-us":{"hash":"en-us_31d920e3c96e6","wasm":"en-us","page_count":10}}}
+{"version":"1.2.0","languages":{"en-us":{"hash":"en-us_74b11568926b7","wasm":"en-us","page_count":10}}}

--- a/libs/components/src/scroll-area/scroll-area-context.ts
+++ b/libs/components/src/scroll-area/scroll-area-context.ts
@@ -4,7 +4,9 @@ export const scrollAreaContextId =
   createContextId<ScrollAreaContext>("scroll-area-context");
 
 export interface ScrollAreaContext {
-  scrollbarRef: Signal<HTMLDivElement | undefined>;
   thumbRef: Signal<HTMLDivElement | undefined>;
   viewportRef: Signal<HTMLDivElement | undefined>;
+  verticalScrollbarRef: Signal<HTMLDivElement | undefined>;
+  horizontalScrollbarRef: Signal<HTMLDivElement | undefined>;
 }
+

--- a/libs/components/src/scroll-area/scroll-area-root.tsx
+++ b/libs/components/src/scroll-area/scroll-area-root.tsx
@@ -14,12 +14,14 @@ type RootProps = PropsOf<"div">;
 export const ScrollAreaRoot = component$<RootProps>((props) => {
   useStyles$(styles);
   const viewportRef = useSignal<HTMLDivElement>();
-  const scrollbarRef = useSignal<HTMLDivElement>();
+  const verticalScrollbarRef = useSignal<HTMLDivElement>();
+  const horizontalScrollbarRef = useSignal<HTMLDivElement>();
   const thumbRef = useSignal<HTMLDivElement>();
 
   const context = {
     viewportRef,
-    scrollbarRef,
+    verticalScrollbarRef,
+    horizontalScrollbarRef,
     thumbRef
   };
 

--- a/libs/components/src/scroll-area/scroll-area-scrollbar.tsx
+++ b/libs/components/src/scroll-area/scroll-area-scrollbar.tsx
@@ -20,7 +20,10 @@ export const ScrollAreaScrollbar = component$<ScrollBarType>((props) => {
   const onTrackClick$ = $((e: MouseEvent) => {
     const target = e.target as HTMLElement;
     const clickedOrientation = target.getAttribute("data-orientation");
-    const scrollbar = context.scrollbarRef.value;
+    const scrollbar = orientation === 'vertical'
+      ? context.verticalScrollbarRef.value
+      : context.horizontalScrollbarRef.value;
+
     if (!scrollbar) return;
 
     const viewport = context.viewportRef.value;
@@ -53,7 +56,7 @@ export const ScrollAreaScrollbar = component$<ScrollBarType>((props) => {
   return (
     <div
       {...props}
-      ref={context.scrollbarRef}
+      ref={orientation === 'vertical' ? context.verticalScrollbarRef : context.horizontalScrollbarRef}
       data-qds-scroll-area-scrollbar
       data-orientation={orientation}
       onClick$={onTrackClick$}

--- a/libs/components/src/scroll-area/scroll-area-view-port.tsx
+++ b/libs/components/src/scroll-area/scroll-area-view-port.tsx
@@ -16,15 +16,9 @@ export const ScrollAreaViewport = component$<ViewPortProps>((props) => {
   const context = useContext(scrollAreaContextId);
   const onScroll$ = $((e: Event) => {
     const viewport = e.target as HTMLElement;
-    const root = viewport.parentElement;
-    if (!root) return;
 
-    const verticalScrollbar = root.querySelector(
-      '[data-qds-scroll-area-scrollbar][data-orientation="vertical"]'
-    ) as HTMLElement;
-    const horizontalScrollbar = root.querySelector(
-      '[data-qds-scroll-area-scrollbar][data-orientation="horizontal"]'
-    ) as HTMLElement;
+    const verticalScrollbar = context.verticalScrollbarRef.value;
+    const horizontalScrollbar = context.horizontalScrollbarRef.value;
 
     if (verticalScrollbar) {
       const verticalThumb = verticalScrollbar.querySelector("[data-qds-scroll-area-thumb]") as HTMLElement;


### PR DESCRIPTION
- [x] We want to avoid using stuff like querySelector and parentElement because these are imperative, but also less performant