### PR TITLE
Run checks on every PR to main, so we can require them

### DIFF
--- a/.github/workflows/check-bound-signal.yml
+++ b/.github/workflows/check-bound-signal.yml
@@ -3,8 +3,6 @@ name: Check useBoundSignal Usage
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - '**/*-root.tsx'
 
 jobs:
   check-bound-signal:

--- a/.github/workflows/check-composition.yml
+++ b/.github/workflows/check-composition.yml
@@ -3,9 +3,6 @@ name: Check Component Composition
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - '**/*.tsx'
-      - '**/*.jsx'
 
 jobs:
   check-composition:

--- a/.github/workflows/check-event-handlers.yml
+++ b/.github/workflows/check-event-handlers.yml
@@ -3,9 +3,6 @@ name: Check Event Handler Patterns
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - '**/*.jsx'
-      - '**/*.tsx'
 
 jobs:
   check-event-handlers:


### PR DESCRIPTION
A few of the checks only run when a PR targets certain files. If we require these checks to pass, PRs that _don't_ target those files could never be merged, because they would wait for a check to pass that never gets triggered. I believe the solution here is to let these checks run every time. The job internally still only checks changed files within the glob pattern, so it shouldn't add much processing time.