### PR TITLE
OSS-16 Date Input improvements

### DIFF
--- a/apps/docs/src/routes/base/date-input/examples/value-based.tsx
+++ b/apps/docs/src/routes/base/date-input/examples/value-based.tsx
@@ -32,11 +32,10 @@ export default component$(() => {
 
       <div class="date-input-button-container">
         <button
-          onClick$={() =>
-            (selectedDate.value = new Date()
-              .toISOString()
-              .split("T")[0] as DateInput.ISODate)
-          }
+          onClick$={() => {
+            const date = new Date().toISOString().split("T")[0] as DateInput.ISODate;
+            selectedDate.value = date;
+          }}
           type="button"
           class="set-value-button"
         >

--- a/apps/docs/src/routes/base/date-input/index.mdx
+++ b/apps/docs/src/routes/base/date-input/index.mdx
@@ -3,6 +3,10 @@ import api from "./code-notate/api.json";
 # Date Input
 A customizable date entry field that allows users to input dates in various formats.
 <Showcase name="hero" />
+
+Note: This component relies on `field-sizing: content;` to set the width of the inputs based on the content of the input or its placeholder. 
+This is supported in Chromium-based browsers, but may not work properly in other browsers.
+If you need to support other or older browsers, you can manage the width of the inputs in your own CSS.
 ## Features
 <Features api={api} />
 ## Anatomy

--- a/libs/components/src/date-input/constants.ts
+++ b/libs/components/src/date-input/constants.ts
@@ -12,6 +12,7 @@ export const DEFAULT_DAY_OF_MONTH_SEGMENT: DateSegment = {
   isPlaceholder: true,
   min: MIN_DAY,
   max: MAX_DAY,
+  maxLength: 2,
   numericValue: undefined,
   isoValue: undefined
 };
@@ -21,6 +22,7 @@ export const DEFAULT_MONTH_SEGMENT: DateSegment = {
   isPlaceholder: true,
   min: MIN_MONTH,
   max: MAX_MONTH,
+  maxLength: 2,
   numericValue: undefined,
   isoValue: undefined
 };
@@ -30,6 +32,7 @@ export const DEFAULT_YEAR_SEGMENT: DateSegment = {
   isPlaceholder: true,
   min: MIN_YEAR,
   max: MAX_YEAR,
+  maxLength: 4,
   numericValue: undefined,
   isoValue: undefined
 };

--- a/libs/components/src/date-input/date-input-day.tsx
+++ b/libs/components/src/date-input/date-input-day.tsx
@@ -21,9 +21,7 @@ export const DateInputDayBase = component$(
       <DateInputSegment
         segmentSig={segmentSig}
         placeholder={placeholder}
-        isEditable={!context.disabledSig.value}
         showLeadingZero={showLeadingZero}
-        maxLength={2}
         {...otherProps}
       />
     );

--- a/libs/components/src/date-input/date-input-month.tsx
+++ b/libs/components/src/date-input/date-input-month.tsx
@@ -21,9 +21,7 @@ export const DateInputMonthBase = component$(
       <DateInputSegment
         segmentSig={segmentSig}
         placeholder={placeholder}
-        isEditable={!context.disabledSig.value}
         showLeadingZero={showLeadingZero}
-        maxLength={2}
         {...otherProps}
       />
     );

--- a/libs/components/src/date-input/date-input-root.tsx
+++ b/libs/components/src/date-input/date-input-root.tsx
@@ -35,7 +35,7 @@ export type DateInputBoundProps = {
 };
 
 // Regular expression for validating ISO date format (yyyy-mm-dd)
-const isoDateRegex = /^\d{4}-(0[1-9]|1[0-2])-\d{2}$/;
+const isoDateRegex = /^\d{1,4}-(0[1-9]|1[0-2])-\d{2}$/;
 
 /** The root Date Input component that manages state and provides context */
 export const DateInputRootBase = component$<PublicDateInputRootProps>((props) => {

--- a/libs/components/src/date-input/date-input-segment.css
+++ b/libs/components/src/date-input/date-input-segment.css
@@ -2,31 +2,11 @@
   input[data-qds-date-input-segment] {
     border: none;
     padding: 0 1px;
-    box-sizing: border-box;
-    grid-area: 1 / 1;
-    width: 100%;
-    min-width: 1ch;
-  }
-
-  input[data-qds-date-input-segment] {
     caret-color: transparent;
+    field-sizing: content;
   }
 
   input[data-qds-date-input-segment]::placeholder {
     text-align: center;
-  }
-
-  .qds-date-input-segment-container {
-    display: inline-grid;
-    width: min-content;
-  }
-
-  .qds-date-input-width-measurement {
-    grid-area: 1 / 1;
-    visibility: hidden;
-    white-space: pre;
-    font: inherit;
-    letter-spacing: inherit;
-    padding: 0 1px;
   }
 }

--- a/libs/components/src/date-input/date-input-segment.css
+++ b/libs/components/src/date-input/date-input-segment.css
@@ -8,6 +8,10 @@
     min-width: 1ch;
   }
 
+  input[data-qds-date-input-segment] {
+    caret-color: transparent;
+  }
+
   input[data-qds-date-input-segment]::placeholder {
     text-align: center;
   }

--- a/libs/components/src/date-input/date-input-segment.tsx
+++ b/libs/components/src/date-input/date-input-segment.tsx
@@ -391,10 +391,8 @@ export const DateInputSegment = component$(
             data-qds-date-input-segment-year={segmentSig.value.type === "year"}
             data-qds-date-input-segment-index={_index}
             value={displayValueSig.value}
-            onKeyDown$={
-              isEditable ? [onKeyDownSync$, onKeyDown$, otherProps.onKeyDown$] : undefined
-            }
-            onInput$={isEditable ? [onInput$, otherProps.onInput$] : undefined}
+            onKeyDown$={[onKeyDownSync$, onKeyDown$, otherProps.onKeyDown$]}
+            onInput$={[onInput$, otherProps.onInput$]}
             onPaste$={[onPasteSync$, otherProps.onPaste$]}
             stoppropagation:change
             placeholder={segmentSig.value.placeholderText}

--- a/libs/components/src/date-input/date-input-segment.tsx
+++ b/libs/components/src/date-input/date-input-segment.tsx
@@ -272,20 +272,12 @@ export const DateInputSegment = component$(
 
       // Handle left/right arrow keys for navigation between segments
       if (event.key === "ArrowRight" && inputRef.value) {
-        const input = inputRef.value;
-        // If cursor is at the end, move to next segment
-        if (input.selectionStart === input.value.length) {
-          await focusNextSegment();
-        }
+        await focusNextSegment();
         return;
       }
 
       if (event.key === "ArrowLeft" && inputRef.value) {
-        const input = inputRef.value;
-        // If cursor is at the beginning, move to previous segment
-        if (input.selectionStart === 0) {
-          await focusPreviousSegment();
-        }
+        await focusPreviousSegment();
       }
     });
 
@@ -337,7 +329,7 @@ export const DateInputSegment = component$(
       const numericContent = content.replace(/\D/g, "");
 
       // If the format specifies leading zeros and the input is 0, allow it
-      if (segment.placeholderText.length > 1 && numericContent === "0") {
+      if (showLeadingZero && numericContent === "0") {
         return;
       }
 

--- a/libs/components/src/date-input/date-input-segment.tsx
+++ b/libs/components/src/date-input/date-input-segment.tsx
@@ -295,6 +295,14 @@ export const DateInputSegment = component$(
       if (event.key === "ArrowLeft" && inputRef.value) {
         await focusPreviousSegment();
       }
+
+      if (
+        event.key === "Backspace" &&
+        inputRef.value &&
+        inputRef.value.value.length === 0
+      ) {
+        await focusPreviousSegment();
+      }
     });
 
     // Use sync$ method to control input

--- a/libs/components/src/date-input/date-input-segment.tsx
+++ b/libs/components/src/date-input/date-input-segment.tsx
@@ -358,53 +358,31 @@ export const DateInputSegment = component$(
       return `${segmentSig.value.numericValue ?? ""}`;
     });
 
-    const usePlaceholderWidth = useComputed$(() => {
-      return !displayValueSig.value.length;
-    });
-
     return (
-      <>
-        <span class="qds-date-input-segment-container">
-          <span
-            class={[
-              "qds-date-input-width-measurement",
-              usePlaceholderWidth.value
-                ? "qds-date-input-width-measurement-placeholder"
-                : ""
-            ]}
-            aria-hidden="true"
-          >
-            {usePlaceholderWidth.value
-              ? segmentSig.value.placeholderText
-              : displayValueSig.value}
-          </span>
-
-          <input
-            {...otherProps}
-            ref={inputRef}
-            id={inputId}
-            type="text"
-            data-qds-date-input-segment
-            data-qds-date-input-segment-placeholder={segmentSig.value.isPlaceholder}
-            data-qds-date-input-segment-day={segmentSig.value.type === "day"}
-            data-qds-date-input-segment-month={segmentSig.value.type === "month"}
-            data-qds-date-input-segment-year={segmentSig.value.type === "year"}
-            data-qds-date-input-segment-index={_index}
-            value={displayValueSig.value}
-            onKeyDown$={[onKeyDownSync$, onKeyDown$, otherProps.onKeyDown$]}
-            onInput$={[onInput$, otherProps.onInput$]}
-            onPaste$={[onPasteSync$, otherProps.onPaste$]}
-            stoppropagation:change
-            placeholder={segmentSig.value.placeholderText}
-            aria-label={`${segmentSig.value.type} input`}
-            aria-valuemax={segmentSig.value.max}
-            aria-valuemin={segmentSig.value.min}
-            aria-valuenow={segmentSig.value.numericValue}
-            disabled={context.disabledSig.value}
-            maxLength={maxLength + 1}
-          />
-        </span>
-      </>
+      <input
+        {...otherProps}
+        ref={inputRef}
+        id={inputId}
+        type="text"
+        data-qds-date-input-segment
+        data-qds-date-input-segment-placeholder={segmentSig.value.isPlaceholder}
+        data-qds-date-input-segment-day={segmentSig.value.type === "day"}
+        data-qds-date-input-segment-month={segmentSig.value.type === "month"}
+        data-qds-date-input-segment-year={segmentSig.value.type === "year"}
+        data-qds-date-input-segment-index={_index}
+        value={displayValueSig.value}
+        onKeyDown$={[onKeyDownSync$, onKeyDown$, otherProps.onKeyDown$]}
+        onInput$={[onInput$, otherProps.onInput$]}
+        onPaste$={[onPasteSync$, otherProps.onPaste$]}
+        stoppropagation:change
+        placeholder={segmentSig.value.placeholderText}
+        aria-label={`${segmentSig.value.type} input`}
+        aria-valuemax={segmentSig.value.max}
+        aria-valuemin={segmentSig.value.min}
+        aria-valuenow={segmentSig.value.numericValue}
+        disabled={context.disabledSig.value}
+        maxLength={maxLength + 1}
+      />
     );
   }
 );

--- a/libs/components/src/date-input/date-input-segment.tsx
+++ b/libs/components/src/date-input/date-input-segment.tsx
@@ -318,7 +318,8 @@ export const DateInputSegment = component$(
 
       // At this point, we know it's a numeric key
       const inputElement = event.target as HTMLInputElement;
-      const currentValue = inputElement.value;
+      // Remove leading zero if present (e.g., "01" -> "1")
+      const currentValue = inputElement.value.replace(/^0/, "");
       const newDigit = event.key;
       const segmentType: DateSegmentType = inputElement.attributes.getNamedItem(
         "data-qds-date-input-segment-year"
@@ -405,6 +406,10 @@ export const DateInputSegment = component$(
     const onInput$ = $(async (event: InputEvent) => {
       const target = event.target as HTMLInputElement;
       const currentValue = target.value;
+
+      if (showLeadingZero && currentValue === "0") {
+        return;
+      }
 
       if (currentValue.length > 0) {
         await updateSegmentWithValue(currentValue);

--- a/libs/components/src/date-input/date-input-year.tsx
+++ b/libs/components/src/date-input/date-input-year.tsx
@@ -21,9 +21,7 @@ export const DateInputYearBase = component$(
       <DateInputSegment
         segmentSig={segmentSig}
         placeholder={placeholder}
-        isEditable={!context.disabledSig.value}
         showLeadingZero={showLeadingZero}
-        maxLength={4}
         {...otherProps}
       />
     );

--- a/libs/components/src/date-input/date-input.test.ts
+++ b/libs/components/src/date-input/date-input.test.ts
@@ -246,7 +246,7 @@ test.describe("Input/Output", () => {
     expect(await monthSegment.inputValue()).toEqual("12");
     await daySegment.pressSequentially("15");
     expect(await daySegment.inputValue()).toEqual("15");
-    await yearSegment.pressSequentially("2025");
+    await yearSegment.pressSequentially("2025", { delay: 50 });
     expect(await yearSegment.inputValue()).toEqual("2025");
 
     await expect(externalValue).toHaveText("2025-12-15");
@@ -260,10 +260,47 @@ test.describe("Input/Output", () => {
     await daySegment.pressSequentially("3");
     expect(await daySegment.inputValue()).toEqual("3");
 
-    await yearSegment.pressSequentially("1999");
+    await yearSegment.pressSequentially("1999", { delay: 50 });
     expect(await yearSegment.inputValue()).toEqual("1999");
 
     await expect(externalValue).toHaveText("1999-09-03");
+  });
+
+  test("GIVEN a date input that uses leading zeros WHEN date info is typed THEN the values should be updated", async ({
+    page
+  }) => {
+    const d = await setup(page, "value-based");
+    const monthSegment = d.getMonthSegment();
+    const yearSegment = d.getYearSegment();
+    const daySegment = d.getDaySegment();
+    const externalValue = d.getExternalValue();
+
+    await page.keyboard.press("Tab");
+    await monthSegment.pressSequentially("05");
+    await expect(monthSegment).toHaveValue("05");
+    await page.keyboard.press("Tab");
+    await daySegment.fill("2");
+    await expect(daySegment).toHaveValue("02");
+    await yearSegment.pressSequentially("2025", { delay: 50 });
+    await expect(yearSegment).toHaveValue("2025");
+
+    await expect(externalValue).toHaveText("2025-05-02");
+
+    await monthSegment.pressSequentially("11");
+    await expect(monthSegment).toHaveValue("11");
+
+    await daySegment.pressSequentially("3");
+    await expect(daySegment).toHaveValue("03");
+
+    await yearSegment.pressSequentially("1999", { delay: 50 });
+    await expect(yearSegment).toHaveValue("1999");
+
+    await expect(externalValue).toHaveText("1999-11-03");
+
+    await monthSegment.pressSequentially("4");
+    await expect(monthSegment).toHaveValue("04");
+
+    await expect(externalValue).toHaveText("1999-04-03");
   });
 });
 

--- a/libs/components/src/date-input/date-input.test.ts
+++ b/libs/components/src/date-input/date-input.test.ts
@@ -232,6 +232,39 @@ test.describe("Input/Output", () => {
     await d.getYearSegment().fill("2024");
     await expect(externalValue).toHaveText("2024-02-14");
   });
+
+  test("GIVEN a date input WHEN date info is typed THEN the values should be updated", async ({
+    page
+  }) => {
+    const d = await setup(page, "hero");
+    const monthSegment = d.getMonthSegment();
+    const yearSegment = d.getYearSegment();
+    const daySegment = d.getDaySegment();
+    const externalValue = d.getExternalValue();
+
+    await monthSegment.pressSequentially("12");
+    expect(await monthSegment.inputValue()).toEqual("12");
+    await daySegment.pressSequentially("15");
+    expect(await daySegment.inputValue()).toEqual("15");
+    await yearSegment.pressSequentially("2025");
+    expect(await yearSegment.inputValue()).toEqual("2025");
+
+    await expect(externalValue).toHaveText("2025-12-15");
+
+    await monthSegment.pressSequentially("11");
+    expect(await monthSegment.inputValue()).toEqual("11");
+
+    await monthSegment.pressSequentially("9");
+    expect(await monthSegment.inputValue()).toEqual("9");
+
+    await daySegment.pressSequentially("3");
+    expect(await daySegment.inputValue()).toEqual("3");
+
+    await yearSegment.pressSequentially("1999");
+    expect(await yearSegment.inputValue()).toEqual("1999");
+
+    await expect(externalValue).toHaveText("1999-09-03");
+  });
 });
 
 test.describe("Disabled", () => {

--- a/libs/components/src/date-input/types.ts
+++ b/libs/components/src/date-input/types.ts
@@ -10,6 +10,7 @@ export type DateSegment = {
   isPlaceholder: boolean;
   min: number;
   max: number;
+  maxLength: number;
 };
 
 export type PublicDateInputSegmentProps = PropsOf<"input"> & {

--- a/libs/components/src/date-input/utils.ts
+++ b/libs/components/src/date-input/utils.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_MONTH_SEGMENT,
   DEFAULT_YEAR_SEGMENT
 } from "./constants";
+import type { DateSegment } from "./types";
 
 export const getSeparatorFromFormat = (format?: DateFormat): Separator => {
   if (format?.includes("/")) return "/";
@@ -12,7 +13,13 @@ export const getSeparatorFromFormat = (format?: DateFormat): Separator => {
   return "/";
 };
 
-export const getInitialSegments = (initialDate: ISODate | null) => {
+export const getInitialSegments = (
+  initialDate: ISODate | null
+): {
+  dayOfMonthSegment: DateSegment;
+  monthSegment: DateSegment;
+  yearSegment: DateSegment;
+} => {
   if (!initialDate) {
     return {
       dayOfMonthSegment: DEFAULT_DAY_OF_MONTH_SEGMENT,
@@ -26,7 +33,6 @@ export const getInitialSegments = (initialDate: ISODate | null) => {
     dayOfMonthSegment: {
       ...DEFAULT_DAY_OF_MONTH_SEGMENT,
       numericValue: +day,
-      displayValue: day,
       isoValue: day,
       max: getLastDayOfMonth(+year, +month),
       isPlaceholder: false
@@ -34,14 +40,12 @@ export const getInitialSegments = (initialDate: ISODate | null) => {
     monthSegment: {
       ...DEFAULT_MONTH_SEGMENT,
       numericValue: +month,
-      displayValue: month,
       isoValue: month,
       isPlaceholder: false
     },
     yearSegment: {
       ...DEFAULT_YEAR_SEGMENT,
       numericValue: +year,
-      displayValue: year,
       isoValue: year,
       isPlaceholder: false
     }


### PR DESCRIPTION
- Update Date Input behaviors
  - left and right arrows always move focus between segments
  - backspace in emptied segment moves focus to the previous segment
  - typing in completed segments replaces the content
- Code cleanup
  - CSS/markup simplification for width setting, using `field-sizing: content;`
  - Simplify event handlers by removing ternaries
  - Fix 'Set to today' button click handler in the value-based example