### PR TITLE
DS-437 Bug with the keyboard in the Switch component while first rendering

### DIFF
--- a/.changeset/three-timers-joke.md
+++ b/.changeset/three-timers-joke.md
@@ -1,0 +1,5 @@
+---
+"@kunai-consulting/qwik": patch
+---
+
+DS-437 Bug with the keyboard in the Switch component while first rendering

--- a/libs/components/src/switch/switch-root.tsx
+++ b/libs/components/src/switch/switch-root.tsx
@@ -70,13 +70,14 @@ const SwitchRootBase = component$<PublicRootProps>((props) => {
     "keydown",
     sync$((event: KeyboardEvent) => {
       const activeElement = document.activeElement;
-      const isWithinSwitch = activeElement?.closest("[data-qds-switch-trigger]");
+      const switchTrigger = activeElement?.closest("[data-qds-switch-trigger]");
 
-      if (!isWithinSwitch) return;
+      if (!switchTrigger) return;
 
       const preventKeys = [" ", "Enter"];
       if (preventKeys.includes(event.key)) {
         event.preventDefault();
+        switchTrigger.setAttribute("data-keypress", event.key);
       }
     })
   );

--- a/libs/components/src/switch/switch-trigger.tsx
+++ b/libs/components/src/switch/switch-trigger.tsx
@@ -17,8 +17,15 @@ const SwitchTriggerBase = component$<PropsOf<"button">>((props) => {
   const triggerRef = useSignal<HTMLButtonElement>();
 
   const handleKeyDown$ = $((event: KeyboardEvent) => {
+    const trigger = triggerRef.value;
+    if (!trigger) return;
+
     if (event.key === " " || event.key === "Enter") {
-      context.toggle$();
+      const keypress = trigger.getAttribute("data-keypress");
+      if (keypress === event.key) {
+        context.toggle$();
+        trigger.removeAttribute("data-keypress");
+      }
     }
   });
 


### PR DESCRIPTION
Initial problem:
1. On the first page load, event handlers were triggered twice:
    * Once by the native keyboard event
    * A second time by our handler inside the component
2. After reloading the page, everything worked correctly because useOnWindow had already been properly initialized.

The fix is the following:
1. When a key is pressed:
    * First, the global handler `(useOnWindow)` triggers
    * It prevents the browser’s default behavior `(preventDefault)`
    * Sets a marker in the DOM `(data-keypress)`
2. Then the component’s handler triggers:
    * It checks for the marker
    * If the marker exists and matches the current key, it performs the toggle
    * Then it removes the marker


What I discovered is that when we navigate using the sidebar menu, the TOC is different from what we get after reloading the page or when the component is selected via the address bar. This applies to all components. 

**Selected from the sidebar:**
<img width="1798" alt="image" src="https://github.com/user-attachments/assets/3eb3ec08-3763-4251-8255-d1d5ec1c036b" />

**After reloading the page:**
<img width="1666" alt="image" src="https://github.com/user-attachments/assets/f50c7199-d5cc-4039-8af7-2e0502ac4872" />
